### PR TITLE
use getter on optionalClasses to make aot happier

### DIFF
--- a/lib/angular2-font-awesome.component.ts
+++ b/lib/angular2-font-awesome.component.ts
@@ -16,7 +16,7 @@ export class Angular2FontAwesomeComponent implements OnInit {
   @Input() rotate     ?: string | number;
   @Input() inverse    ?: boolean;
 
-  private optionalClasses: string[] = [];
+  private _optionalClasses: string[] = [];
   constructor() { }
 
   ngOnInit() {
@@ -46,9 +46,13 @@ export class Angular2FontAwesomeComponent implements OnInit {
     }
 
   }
+  
+  get optionalClasses() {
+    return this._optionalClasses;
+  }
 
   private addToOptionalClasses(addClass: string): void {
-    this.optionalClasses.push(addClass);
+    this._optionalClasses.push(addClass);
   }
 
 }


### PR DESCRIPTION
With the 1.0.0 release of ng cli I was getting errors associated with aot compilation due to accessing a private member from the template. This just adds a getter to optionalClasses to resolve the error.